### PR TITLE
Optimize Next.js performance demo

### DIFF
--- a/docs/performance-plan.md
+++ b/docs/performance-plan.md
@@ -1,0 +1,17 @@
+# Performance follow-ups
+
+This branch focuses on improvements that preserve the core demo goal: making the Hyperdrive vs direct database latency difference visible.
+
+## Implemented in `optimize-next`
+
+- Bean detail pages render as Server Components while still selecting direct vs Hyperdrive from `?hyperdrive=true|false` with cookie fallback.
+- Internal bean links and pagination API calls append the current Hyperdrive mode so the comparison survives navigation.
+- Count and page queries run concurrently to remove unnecessary request waterfalls without hiding database latency.
+- The shared page shell is now a Server Component; only the latency stats panel remains client-side.
+- Removed the unused Geist Mono font and unused `tw-animate-css` import.
+
+## Deferred
+
+- Add an explicit optimized/cache mode later: direct, Hyperdrive, and Hyperdrive + app/edge/query cache. This should be separate from the baseline modes so caching does not hide the Hyperdrive comparison.
+- Revisit replacing `js-cookie`, Zustand, global theme runtime, and always-loaded toast code if the client bundle remains too large after the server-boundary work.
+- Add Cloudflare image transformations or prebuilt responsive variants when the demo moves from small sample images to larger production-like assets.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,14 @@ import nextTypescript from "eslint-config-next/typescript";
 
 const eslintConfig = [
 	{
-		ignores: [".open-next/**", ".wrangler/**", "cloudflare-env.d.ts", "coverage/**"],
+		ignores: [
+			".next/**",
+			".open-next/**",
+			".wrangler/**",
+			"dist/**",
+			"cloudflare-env.d.ts",
+			"coverage/**",
+		],
 	},
 	...nextCoreWebVitals,
 	...nextTypescript,

--- a/src/app/api/beans/[id]/route.ts
+++ b/src/app/api/beans/[id]/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/db';
 import { coffeeBeans, suppliers } from '@/db/schema';
 import { eq } from 'drizzle-orm';
+import {
+  HYPERDRIVE_COOKIE,
+  resolveHyperdrivePreference,
+} from '@/lib/hyperdrive-mode';
 
 export async function GET(
   request: NextRequest,
@@ -19,7 +23,10 @@ export async function GET(
     }
 
     // Read cookie to determine which connection to use
-    const useHyperdrive = request.cookies.get('use-hyperdrive')?.value === 'true';
+    const useHyperdrive = resolveHyperdrivePreference({
+      searchParams: request.nextUrl.searchParams,
+      cookieValue: request.cookies.get(HYPERDRIVE_COOKIE)?.value,
+    });
     const { db, isUsingHyperdrive } = await getDb(useHyperdrive);
 
     // Measure database query time

--- a/src/app/api/beans/route.ts
+++ b/src/app/api/beans/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/db';
 import { coffeeBeans } from '@/db/schema';
 import { count } from 'drizzle-orm';
+import {
+  HYPERDRIVE_COOKIE,
+  resolveHyperdrivePreference,
+} from '@/lib/hyperdrive-mode';
 
 const BEANS_PER_PAGE = 6; // 2 rows × 3 columns
 
@@ -15,23 +19,20 @@ export async function GET(request: NextRequest) {
     const offset = (currentPage - 1) * BEANS_PER_PAGE;
 
     // Read cookie to determine which connection to use
-    const useHyperdrive = request.cookies.get('use-hyperdrive')?.value === 'true';
+    const useHyperdrive = resolveHyperdrivePreference({
+      searchParams,
+      cookieValue: request.cookies.get(HYPERDRIVE_COOKIE)?.value,
+    });
     const { db, isUsingHyperdrive } = await getDb(useHyperdrive);
 
     // Measure database query time (using Date.now() for Cloudflare Workers compatibility)
     const dbStartTime = Date.now();
 
-    // Get total count for pagination
-    const [{ value: totalCount }] = await db
-      .select({ value: count() })
-      .from(coffeeBeans);
-
-    // Get beans for current page
-    const beans = await db
-      .select()
-      .from(coffeeBeans)
-      .limit(BEANS_PER_PAGE)
-      .offset(offset);
+    // Count and page queries are independent, so run them concurrently.
+    const [[{ value: totalCount }], beans] = await Promise.all([
+      db.select({ value: count() }).from(coffeeBeans),
+      db.select().from(coffeeBeans).limit(BEANS_PER_PAGE).offset(offset),
+    ]);
 
     const dbEndTime = Date.now();
     const dbDurationMs = dbEndTime - dbStartTime;

--- a/src/app/beans/[id]/error.tsx
+++ b/src/app/beans/[id]/error.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function BeanDetailError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Bean detail render failed:', error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-stone-50 to-stone-100">
+      <div className="container mx-auto px-4 py-12 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl rounded-xl border border-amber-200 bg-white p-8 shadow-sm">
+          <div className="mb-4 flex items-center gap-3 text-amber-700">
+            <AlertTriangle className="h-6 w-6" />
+            <h1 className="text-2xl font-bold text-stone-900">Bean detail failed to load</h1>
+          </div>
+
+          <p className="mb-4 text-stone-600">
+            The server render for this coffee bean failed. In this demo that usually means
+            the selected database connection mode could not complete a query.
+          </p>
+
+          <div className="mb-6 rounded-lg bg-stone-50 p-4 text-sm text-stone-600">
+            <p>
+              <span className="font-semibold text-stone-800">Safe detail:</span>{' '}
+              Try toggling Hyperdrive or returning to the catalog and loading another bean.
+            </p>
+            {error.digest && (
+              <p className="mt-2 font-mono text-xs text-stone-500">Digest: {error.digest}</p>
+            )}
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <Button type="button" onClick={reset}>Try again</Button>
+            <Button asChild variant="outline">
+              <Link href="/">Back to catalog</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/beans/[id]/page.tsx
+++ b/src/app/beans/[id]/page.tsx
@@ -1,41 +1,20 @@
-'use client';
-
-import { useEffect, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
 import Image from 'next/image';
-import { toast } from 'sonner';
-import { ArrowLeft, Globe, Leaf } from 'lucide-react';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { eq } from 'drizzle-orm';
+import { AlertTriangle, ArrowLeft, Globe, Leaf } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { CoffeeBeanDetailSkeleton } from '@/components/coffee-bean-detail-skeleton';
 import { PageShell } from '@/components/page-shell';
-import { useLatencyStore } from '@/lib/latency-store';
-
-interface CoffeeBean {
-  id: number;
-  name: string;
-  description: string | null;
-  imageKey: string | null;
-  tastingNotes: string | null;
-  priceInCents: number;
-  roastLevel: 'Light' | 'Medium' | 'Dark' | 'Espresso' | null;
-  supplierId: number | null;
-}
-
-interface Supplier {
-  id: number;
-  name: string;
-  country: string;
-  isFairTrade: boolean | null;
-  websiteUrl: string | null;
-}
-
-interface BeanApiResponse {
-  bean: CoffeeBean;
-  supplier: Supplier | null;
-  isUsingHyperdrive: boolean;
-  dbDurationMs: number;
-}
+import { BeanDetailLatencyRecorder } from '@/components/bean-detail-latency-recorder';
+import { getDb } from '@/db';
+import { coffeeBeans, suppliers } from '@/db/schema';
+import {
+  HYPERDRIVE_COOKIE,
+  resolveHyperdrivePreference,
+  withHyperdriveParam,
+} from '@/lib/hyperdrive-mode';
 
 const ROAST_COLORS = {
   Light: 'bg-amber-100 text-amber-800',
@@ -44,88 +23,131 @@ const ROAST_COLORS = {
   Espresso: 'bg-stone-900 text-stone-50',
 };
 
-export default function BeanDetailPage() {
-  const params = useParams();
-  const router = useRouter();
-  const [data, setData] = useState<BeanApiResponse | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const addRecord = useLatencyStore((state) => state.addRecord);
+async function getBeanDetailData(beanId: number, useHyperdrive: boolean) {
+  const requestStartTime = Date.now();
+  const { db, isUsingHyperdrive } = await getDb(useHyperdrive);
 
-  useEffect(() => {
-    const fetchBean = async () => {
-      setIsLoading(true);
-      setError(null);
+  const dbStartTime = Date.now();
+  const result = await db
+    .select({
+      bean: coffeeBeans,
+      supplier: suppliers,
+    })
+    .from(coffeeBeans)
+    .leftJoin(suppliers, eq(coffeeBeans.supplierId, suppliers.id))
+    .where(eq(coffeeBeans.id, beanId))
+    .limit(1);
+  const dbDurationMs = Date.now() - dbStartTime;
+  const totalMs = Date.now() - requestStartTime;
 
-      const startTime = performance.now();
+  return {
+    result,
+    dbDurationMs,
+    totalMs,
+    isUsingHyperdrive,
+  };
+}
 
-      try {
-        const response = await fetch(`/api/beans/${params.id}`);
-
-        if (!response.ok) {
-          if (response.status === 404) {
-            setError('Coffee bean not found');
-          } else {
-            setError('Failed to load coffee bean');
-          }
-          return;
-        }
-
-        const result = await response.json() as BeanApiResponse;
-        const endTime = performance.now();
-        const totalMs = Math.round(endTime - startTime);
-
-        setData(result);
-
-        // Record latency stats
-        addRecord({
-          totalMs,
-          dbMs: result.dbDurationMs,
-          isHyperdrive: result.isUsingHyperdrive,
-        });
-
-        // Show toast
-        const connectionType = result.isUsingHyperdrive ? 'Hyperdrive' : 'Direct';
-        toast.success(`Loaded ${result.bean.name}`, {
-          description: `${result.dbDurationMs}ms db / ${totalMs}ms total (${connectionType})`,
-        });
-      } catch (err) {
-        console.error('Error fetching bean:', err);
-        setError('Failed to load coffee bean');
-        toast.error('Failed to load coffee bean');
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    if (params.id) {
-      fetchBean();
+function getSafeBeanDetailError(error: unknown) {
+  if (error instanceof Error) {
+    if (error.message.includes('No database connection string')) {
+      return 'Database connection is not configured for the selected mode.';
     }
-  }, [params.id, addRecord]);
 
-  if (isLoading) {
-    return (
-      <PageShell>
-        <CoffeeBeanDetailSkeleton />
-      </PageShell>
-    );
+    if (/timeout|timed out|connect|connection|ECONN/i.test(error.message)) {
+      return 'Database connection failed or timed out for the selected mode.';
+    }
   }
 
-  if (error || !data) {
-    return (
-      <PageShell>
-        <div className="max-w-4xl mx-auto text-center py-12">
-          <p className="text-stone-600 mb-4">{error || 'Something went wrong'}</p>
-          <Button variant="outline" onClick={() => router.push('/')}>
+  return 'Database query failed while loading this bean detail.';
+}
+
+function BeanDetailInlineError({
+  beanId,
+  useHyperdrive,
+  error,
+}: {
+  beanId: number;
+  useHyperdrive: boolean;
+  error: unknown;
+}) {
+  const connectionType = useHyperdrive ? 'Hyperdrive' : 'Direct';
+
+  return (
+    <PageShell useHyperdrive={useHyperdrive}>
+      <div className="mx-auto max-w-2xl rounded-xl border border-amber-200 bg-white p-8 shadow-sm">
+        <div className="mb-4 flex items-center gap-3 text-amber-700">
+          <AlertTriangle className="h-6 w-6" />
+          <h1 className="text-2xl font-bold text-stone-900">Could not load bean #{beanId}</h1>
+        </div>
+
+        <p className="mb-4 text-stone-600">{getSafeBeanDetailError(error)}</p>
+
+        <div className="mb-6 rounded-lg bg-stone-50 p-4 text-sm text-stone-600">
+          <p>
+            <span className="font-semibold text-stone-800">Connection mode:</span>{' '}
+            {connectionType}
+          </p>
+          <p className="mt-2 text-xs text-stone-500">
+            The full error is logged server-side. This panel only shows a sanitized demo-safe summary.
+          </p>
+        </div>
+
+        <Button asChild variant="outline">
+          <Link href={withHyperdriveParam('/', useHyperdrive)}>
             <ArrowLeft className="w-4 h-4 mr-2" />
             Back to all beans
-          </Button>
-        </div>
-      </PageShell>
+          </Link>
+        </Button>
+      </div>
+    </PageShell>
+  );
+}
+
+export default async function BeanDetailPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [{ id }, resolvedSearchParams, cookieStore] = await Promise.all([
+    params,
+    searchParams,
+    cookies(),
+  ]);
+  const beanId = parseInt(id, 10);
+
+  if (isNaN(beanId)) {
+    notFound();
+  }
+
+  const useHyperdrive = resolveHyperdrivePreference({
+    searchParams: resolvedSearchParams,
+    cookieValue: cookieStore.get(HYPERDRIVE_COOKIE)?.value,
+  });
+  let detailData: Awaited<ReturnType<typeof getBeanDetailData>>;
+
+  try {
+    detailData = await getBeanDetailData(beanId, useHyperdrive);
+  } catch (error) {
+    console.error('Failed to load bean detail:', error);
+    return (
+      <BeanDetailInlineError
+        beanId={beanId}
+        useHyperdrive={useHyperdrive}
+        error={error}
+      />
     );
   }
 
-  const { bean, supplier } = data;
+  const { result, dbDurationMs, totalMs, isUsingHyperdrive } = detailData;
+
+  if (result.length === 0) {
+    notFound();
+  }
+
+  const { bean, supplier } = result[0];
   const price = (bean.priceInCents / 100).toFixed(2);
 
   const imageUrl = bean.imageKey
@@ -133,16 +155,20 @@ export default function BeanDetailPage() {
     : `https://placehold.co/600x600/8b7355/ffffff?text=${encodeURIComponent(bean.name)}`;
 
   return (
-    <PageShell>
+    <PageShell useHyperdrive={useHyperdrive}>
+      <BeanDetailLatencyRecorder
+        beanName={bean.name}
+        dbDurationMs={dbDurationMs}
+        totalMs={totalMs}
+        isUsingHyperdrive={isUsingHyperdrive}
+      />
       <div className="max-w-4xl mx-auto">
         {/* Back button */}
-        <Button
-          variant="ghost"
-          onClick={() => router.push('/')}
-          className="mb-6 -ml-2 text-stone-600 hover:text-stone-900"
-        >
-          <ArrowLeft className="w-4 h-4 mr-2" />
-          Back to all beans
+        <Button asChild variant="ghost" className="mb-6 -ml-2 text-stone-600 hover:text-stone-900">
+          <Link href={withHyperdriveParam('/', useHyperdrive)}>
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Back to all beans
+          </Link>
         </Button>
 
         <div className="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -7,7 +6,6 @@
 	--color-background: var(--background);
 	--color-foreground: var(--foreground);
 	--font-sans: var(--font-geist-sans);
-	--font-mono: var(--font-geist-mono);
 	--color-sidebar-ring: var(--sidebar-ring);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
@@ -7,11 +7,6 @@ import { HyperdriveToggle } from "@/components/hyperdrive-toggle";
 
 const geistSans = Geist({
 	variable: "--font-geist-sans",
-	subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-	variable: "--font-geist-mono",
 	subsets: ["latin"],
 });
 
@@ -30,7 +25,7 @@ export default function RootLayout({
 			<head>
 				<link rel="icon" href="/favicon.svg" type="image/svg+xml"></link>
 			</head>
-			<body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+			<body className={`${geistSans.variable} antialiased`}>
 				<ThemeProvider
 					attribute="class"
 					defaultTheme="system"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,31 +4,41 @@ import { count } from 'drizzle-orm';
 import { CoffeeBeansGrid } from '@/components/coffee-beans-grid';
 import { PageShell } from '@/components/page-shell';
 import { cookies } from 'next/headers';
+import {
+	HYPERDRIVE_COOKIE,
+	resolveHyperdrivePreference,
+} from '@/lib/hyperdrive-mode';
 
 const BEANS_PER_PAGE = 6;
 
-export default async function Home() {
-	const cookieStore = await cookies();
-	const useHyperdrive = cookieStore.get('use-hyperdrive')?.value === 'true';
+export default async function Home({
+	searchParams,
+}: {
+	searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+	const [resolvedSearchParams, cookieStore] = await Promise.all([
+		searchParams,
+		cookies(),
+	]);
+	const useHyperdrive = resolveHyperdrivePreference({
+		searchParams: resolvedSearchParams,
+		cookieValue: cookieStore.get(HYPERDRIVE_COOKIE)?.value,
+	});
 	const { db } = await getDb(useHyperdrive);
 
 	// Fetch initial page server-side
-	const [{ value: totalCount }] = await db
-		.select({ value: count() })
-		.from(coffeeBeans);
-
-	const beans = await db
-		.select()
-		.from(coffeeBeans)
-		.limit(BEANS_PER_PAGE)
-		.offset(0);
+	const [[{ value: totalCount }], beans] = await Promise.all([
+		db.select({ value: count() }).from(coffeeBeans),
+		db.select().from(coffeeBeans).limit(BEANS_PER_PAGE).offset(0),
+	]);
 
 	const totalPages = Math.ceil(totalCount / BEANS_PER_PAGE);
 
 	return (
-		<PageShell>
+		<PageShell useHyperdrive={useHyperdrive}>
 			<CoffeeBeansGrid
 				initialBeans={beans}
+				useHyperdrive={useHyperdrive}
 				initialPagination={{
 					currentPage: 1,
 					totalPages,

--- a/src/components/bean-detail-latency-recorder.tsx
+++ b/src/components/bean-detail-latency-recorder.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect } from 'react';
+import { toast } from 'sonner';
+import { useLatencyStore } from '@/lib/latency-store';
+
+interface BeanDetailLatencyRecorderProps {
+	beanName: string;
+	dbDurationMs: number;
+	totalMs: number;
+	isUsingHyperdrive: boolean;
+}
+
+export function BeanDetailLatencyRecorder({
+	beanName,
+	dbDurationMs,
+	totalMs,
+	isUsingHyperdrive,
+}: BeanDetailLatencyRecorderProps) {
+	const addRecord = useLatencyStore((state) => state.addRecord);
+
+	useEffect(() => {
+		addRecord({
+			totalMs,
+			dbMs: dbDurationMs,
+			isHyperdrive: isUsingHyperdrive,
+		});
+
+		const connectionType = isUsingHyperdrive ? 'Hyperdrive' : 'Direct';
+		toast.success(`Loaded ${beanName}`, {
+			description: `${dbDurationMs}ms db / ${totalMs}ms server (${connectionType})`,
+		});
+	}, [addRecord, beanName, dbDurationMs, isUsingHyperdrive, totalMs]);
+
+	return null;
+}

--- a/src/components/coffee-bean-card.tsx
+++ b/src/components/coffee-bean-card.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { withHyperdriveParam } from '@/lib/hyperdrive-mode';
 
 interface CoffeeBeanCardProps {
   id: number;
@@ -10,6 +11,7 @@ interface CoffeeBeanCardProps {
   priceInCents: number;
   roastLevel: 'Light' | 'Medium' | 'Dark' | 'Espresso' | null;
   eager?: boolean;
+  useHyperdrive?: boolean;
 }
 
 const ROAST_COLORS = {
@@ -28,8 +30,13 @@ export function CoffeeBeanCard({
   priceInCents,
   roastLevel,
   eager = false,
+  useHyperdrive,
 }: CoffeeBeanCardProps) {
   const price = (priceInCents / 100).toFixed(2);
+  const href =
+    typeof useHyperdrive === 'boolean'
+      ? withHyperdriveParam(`/beans/${id}`, useHyperdrive)
+      : `/beans/${id}`;
 
   // Construct R2 image URL
   const imageUrl = imageKey
@@ -38,7 +45,8 @@ export function CoffeeBeanCard({
 
   return (
     <Link
-      href={`/beans/${id}`}
+      href={href}
+      prefetch={false}
       className="group block overflow-hidden rounded-lg border border-stone-200 bg-white shadow-sm transition-all hover:shadow-md hover:border-stone-300"
     >
       {/* Image */}

--- a/src/components/coffee-beans-grid.tsx
+++ b/src/components/coffee-beans-grid.tsx
@@ -36,6 +36,7 @@ interface PaginationInfo {
 interface CoffeeBeansGridProps {
   initialBeans: CoffeeBean[];
   initialPagination: PaginationInfo;
+  useHyperdrive: boolean;
 }
 
 interface BeansApiResponse {
@@ -48,6 +49,7 @@ interface BeansApiResponse {
 export function CoffeeBeansGrid({
   initialBeans,
   initialPagination,
+  useHyperdrive,
 }: CoffeeBeansGridProps) {
   const [beans, setBeans] = useState<CoffeeBean[]>(initialBeans);
   const [pagination, setPagination] = useState<PaginationInfo>(initialPagination);
@@ -59,7 +61,7 @@ export function CoffeeBeansGrid({
     const startTime = performance.now();
 
     try {
-      const response = await fetch(`/api/beans?page=${page}`);
+      const response = await fetch(`/api/beans?page=${page}&hyperdrive=${useHyperdrive ? 'true' : 'false'}`);
       if (!response.ok) throw new Error('Failed to fetch beans');
 
       const data = await response.json() as BeansApiResponse;
@@ -152,7 +154,12 @@ export function CoffeeBeansGrid({
         ) : (
           // Show actual beans when not loading
           beans.map((bean, index) => (
-            <CoffeeBeanCard key={bean.id} {...bean} eager={index < 3} />
+            <CoffeeBeanCard
+              key={bean.id}
+              {...bean}
+              eager={index < 3}
+              useHyperdrive={useHyperdrive}
+            />
           ))
         )}
       </div>

--- a/src/components/hyperdrive-toggle.tsx
+++ b/src/components/hyperdrive-toggle.tsx
@@ -4,6 +4,11 @@ import { Rocket } from 'lucide-react';
 import { Toggle } from '@/components/ui/toggle';
 import { useSyncExternalStore } from 'react';
 import Cookies from 'js-cookie';
+import {
+	HYPERDRIVE_COOKIE,
+	HYPERDRIVE_QUERY_PARAM,
+	parseBooleanPreference,
+} from '@/lib/hyperdrive-mode';
 
 const hyperdriveToggleListeners = new Set<() => void>();
 
@@ -13,7 +18,14 @@ function subscribeToHyperdriveToggle(listener: () => void) {
 }
 
 function getHyperdriveToggleSnapshot() {
-	return Cookies.get('use-hyperdrive') === 'true';
+	const queryPreference =
+		typeof window === 'undefined'
+			? undefined
+			: parseBooleanPreference(
+					new URLSearchParams(window.location.search).get(HYPERDRIVE_QUERY_PARAM)
+				);
+
+	return queryPreference ?? (Cookies.get(HYPERDRIVE_COOKIE) === 'true');
 }
 
 function getServerHyperdriveToggleSnapshot() {
@@ -34,8 +46,12 @@ export function HyperdriveToggle() {
 	);
 
 	const handleToggle = (pressed: boolean) => {
-		Cookies.set('use-hyperdrive', pressed ? 'true' : 'false', { expires: 365 });
+		Cookies.set(HYPERDRIVE_COOKIE, pressed ? 'true' : 'false', { expires: 365 });
 		notifyHyperdriveToggleListeners();
+
+		const url = new URL(window.location.href);
+		url.searchParams.set(HYPERDRIVE_QUERY_PARAM, pressed ? 'true' : 'false');
+		window.location.assign(url.toString());
 	};
 
 	return (

--- a/src/components/latency-stats-panel.tsx
+++ b/src/components/latency-stats-panel.tsx
@@ -6,6 +6,7 @@ import { Zap, Database, Activity } from 'lucide-react';
 
 export function LatencyStatsPanel() {
   const records = useLatencyStore((state) => state.records);
+  const clearRecords = useLatencyStore((state) => state.clearRecords);
   const stats = computeStats(records);
 
   // Calculate improvement percentage when we have both types
@@ -117,7 +118,7 @@ export function LatencyStatsPanel() {
       {/* Last request indicator */}
       {stats.lastRecord && (
         <div className="border-t border-stone-200/50 px-5 py-2.5 bg-stone-50/50">
-          <div className="flex items-center justify-center gap-4 text-xs text-stone-500">
+          <div className="flex flex-wrap items-center justify-center gap-4 text-xs text-stone-500">
             <span>
               Last request:{' '}
               <span className={`font-semibold ${stats.lastRecord.isHyperdrive ? 'text-orange-600' : 'text-stone-600'}`}>
@@ -145,6 +146,13 @@ export function LatencyStatsPanel() {
                 </>
               )}
             </span>
+            <button
+              type="button"
+              onClick={clearRecords}
+              className="text-[10px] font-medium uppercase tracking-wide text-stone-400 underline-offset-2 hover:text-stone-600 hover:underline"
+            >
+              Reset
+            </button>
           </div>
         </div>
       )}

--- a/src/components/page-shell.tsx
+++ b/src/components/page-shell.tsx
@@ -1,21 +1,30 @@
-'use client';
-
 import Link from 'next/link';
 import { LatencyStatsPanel } from '@/components/latency-stats-panel';
+import { withHyperdriveParam } from '@/lib/hyperdrive-mode';
 
 interface PageShellProps {
   children: React.ReactNode;
   showHeader?: boolean;
+  useHyperdrive?: boolean;
 }
 
-export function PageShell({ children, showHeader = true }: PageShellProps) {
+export function PageShell({
+  children,
+  showHeader = true,
+  useHyperdrive,
+}: PageShellProps) {
+  const homeHref =
+    typeof useHyperdrive === 'boolean'
+      ? withHyperdriveParam('/', useHyperdrive)
+      : '/';
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-stone-50 to-stone-100">
       <div className="container mx-auto px-4 py-12 sm:px-6 lg:px-8">
         {/* Header */}
         {showHeader && (
           <header className="mb-8 text-center">
-            <Link href="/" className="inline-block">
+            <Link href={homeHref} className="inline-block">
               <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-stone-900 mb-4 tracking-tight hover:text-stone-700 transition-colors">
                 The Coffee Cluster
               </h1>

--- a/src/lib/hyperdrive-mode.ts
+++ b/src/lib/hyperdrive-mode.ts
@@ -1,0 +1,51 @@
+export const HYPERDRIVE_COOKIE = 'use-hyperdrive';
+export const HYPERDRIVE_QUERY_PARAM = 'hyperdrive';
+
+type SearchParamsLike =
+	| URLSearchParams
+	| Record<string, string | string[] | undefined>
+	| undefined;
+
+function firstValue(value: string | string[] | null | undefined) {
+	return Array.isArray(value) ? value[0] : value;
+}
+
+export function parseBooleanPreference(value: string | null | undefined) {
+	if (value === 'true' || value === '1' || value === 'on') return true;
+	if (value === 'false' || value === '0' || value === 'off') return false;
+	return undefined;
+}
+
+export function getSearchParamValue(
+	searchParams: SearchParamsLike,
+	key = HYPERDRIVE_QUERY_PARAM
+) {
+	if (!searchParams) return undefined;
+
+	if (searchParams instanceof URLSearchParams) {
+		return searchParams.get(key) ?? undefined;
+	}
+
+	return firstValue(searchParams[key]);
+}
+
+export function resolveHyperdrivePreference({
+	searchParams,
+	cookieValue,
+	defaultValue = false,
+}: {
+	searchParams?: SearchParamsLike;
+	cookieValue?: string | null;
+	defaultValue?: boolean;
+}) {
+	return (
+		parseBooleanPreference(getSearchParamValue(searchParams)) ??
+		parseBooleanPreference(cookieValue ?? undefined) ??
+		defaultValue
+	);
+}
+
+export function withHyperdriveParam(href: string, useHyperdrive: boolean) {
+	const separator = href.includes('?') ? '&' : '?';
+	return `${href}${separator}${HYPERDRIVE_QUERY_PARAM}=${useHyperdrive ? 'true' : 'false'}`;
+}

--- a/src/lib/latency-store.ts
+++ b/src/lib/latency-store.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 export interface LatencyRecord {
   timestamp: number;
@@ -15,17 +16,26 @@ interface LatencyStats {
   clearRecords: () => void;
 }
 
-export const useLatencyStore = create<LatencyStats>((set) => ({
-  records: [],
-  addRecord: (record) =>
-    set((state) => ({
-      records: [
-        ...state.records.slice(-19), // Keep last 20 records
-        { ...record, timestamp: Date.now() },
-      ],
-    })),
-  clearRecords: () => set({ records: [] }),
-}));
+export const useLatencyStore = create<LatencyStats>()(
+  persist(
+    (set) => ({
+      records: [],
+      addRecord: (record) =>
+        set((state) => ({
+          records: [
+            ...state.records.slice(-19), // Keep last 20 records
+            { ...record, timestamp: Date.now() },
+          ],
+        })),
+      clearRecords: () => set({ records: [] }),
+    }),
+    {
+      name: 'coffee-cluster-latency-records',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ records: state.records }),
+    }
+  )
+);
 
 // Helper functions for computing stats
 export function computeStats(records: LatencyRecord[]) {


### PR DESCRIPTION
## Summary
- Convert bean detail pages to server-rendered data loading while preserving direct vs Hyperdrive mode selection
- Propagate the Hyperdrive mode through URLs, API calls, navigation, and the toggle
- Persist latency records across mode toggles so direct and Hyperdrive runs can be compared
- Parallelize independent bean count/page queries and reduce client boundaries
- Remove unused mono font and animation CSS; document deferred cache/bundle/image follow-ups

## Verification
- pnpm lint
- pnpm test:run
- pnpm build